### PR TITLE
Fix rom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ cd gym-rle
 pip install -e .
 ```
 
-Roms for the available games need to put in the gym/envs/rle/roms dir with lowercase separated names (e.g. mortal_kombat.sfc).
+Roms for the available games need to put in the `gym_rle/envs/roms` dir with lowercase separated names (e.g. mortal_kombat.sfc).
 You can see the list of supported games in `gym_rle/__init__.py` .

--- a/gym_rle/envs/roms/readme.txt
+++ b/gym_rle/envs/roms/readme.txt
@@ -1,2 +1,2 @@
-In this directory goes the SNES ROM files (ending in .sfc).
+In this directory goes the SNES ROM files (ending in .sfc or .smc).
 File names should be lowercase separated by underscores.


### PR DESCRIPTION
I noticed that the path for the example game didn't match the path in the README and that the example game was `.smc`. Other `.smc` SNES roms I tested also worked.
  